### PR TITLE
feat: Highlights for Books landing & privacy pages

### DIFF
--- a/components/HighlightsForBooks/HighlightsLanding.module.scss
+++ b/components/HighlightsForBooks/HighlightsLanding.module.scss
@@ -1,0 +1,258 @@
+@use "../../styles/variables" as *;
+
+.page {
+  min-height: 100vh;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.hero {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 140px $spacing-md $spacing-xl;
+  text-align: center;
+
+  @media (max-width: $breakpoint-md) {
+    padding: 110px $spacing-sm $spacing-lg;
+  }
+}
+
+.appName {
+  font-family: var(--font-primary);
+  font-size: 3rem;
+  font-weight: 700;
+  color: var(--text-color);
+  margin: 0 0 $spacing-sm;
+  line-height: 1.15;
+
+  @media (max-width: $breakpoint-md) {
+    font-size: 2.25rem;
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    font-size: 1.875rem;
+  }
+}
+
+.tagline {
+  font-size: 1.25rem;
+  color: var(--text-color-secondary);
+  line-height: 1.6;
+  margin: 0 0 $spacing-lg;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+
+  @media (max-width: $breakpoint-sm) {
+    font-size: 1.0625rem;
+  }
+}
+
+.platformBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  font-size: $font-size-sm;
+  color: var(--text-color-secondary);
+  margin-bottom: $spacing-md;
+}
+
+.ctaGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-sm;
+}
+
+.ctaButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: var(--primary-color);
+  color: #fff;
+  font-family: var(--font-primary);
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 14px 32px;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+
+  &:hover {
+    background-color: #d93e3e;
+    color: #fff;
+    transform: translateY(-1px);
+  }
+}
+
+.price {
+  font-size: $font-size-sm;
+  color: var(--text-color-secondary);
+}
+
+// Features Section
+.features {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 $spacing-md $spacing-2xl;
+
+  @media (max-width: $breakpoint-md) {
+    padding: 0 $spacing-sm $spacing-xl;
+  }
+}
+
+.sectionTitle {
+  font-family: var(--font-primary);
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-color);
+  margin: 0 0 $spacing-lg;
+  text-align: center;
+
+  @media (max-width: $breakpoint-sm) {
+    font-size: 1.25rem;
+  }
+}
+
+.featureGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: $spacing-md;
+
+  @media (max-width: $breakpoint-sm) {
+    grid-template-columns: 1fr;
+    gap: $spacing-sm;
+  }
+}
+
+.featureCard {
+  padding: $spacing-md;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 0;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: $shadow-md;
+  }
+}
+
+.featureIcon {
+  font-size: 1.5rem;
+  margin-bottom: $spacing-xs;
+  display: block;
+}
+
+.featureTitle {
+  font-family: var(--font-primary);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-color);
+  margin: 0 0 0.25rem;
+}
+
+.featureDesc {
+  font-size: $font-size-sm;
+  color: var(--text-color-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+// Requirements Section
+.requirements {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 $spacing-md $spacing-2xl;
+  text-align: center;
+
+  @media (max-width: $breakpoint-md) {
+    padding: 0 $spacing-sm $spacing-xl;
+  }
+}
+
+.requirementsList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  gap: $spacing-lg;
+  flex-wrap: wrap;
+}
+
+.requirementItem {
+  font-size: $font-size-sm;
+  color: var(--text-color-secondary);
+
+  strong {
+    color: var(--text-color);
+    font-weight: 600;
+  }
+}
+
+// Support Section
+.support {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 $spacing-md $spacing-2xl;
+  text-align: center;
+
+  @media (max-width: $breakpoint-md) {
+    padding: 0 $spacing-sm $spacing-xl;
+  }
+}
+
+.supportText {
+  font-size: 1rem;
+  color: var(--text-color-secondary);
+  line-height: 1.6;
+  margin: 0 0 $spacing-sm;
+}
+
+.supportEmail {
+  display: inline-block;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--primary-color);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.3s ease;
+
+  &:hover {
+    border-bottom-color: var(--primary-color);
+    color: var(--primary-color);
+  }
+}
+
+// Footer Links
+.footerLinks {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 $spacing-md $spacing-2xl;
+  text-align: center;
+  border-top: 1px solid var(--card-border);
+  padding-top: $spacing-lg;
+
+  @media (max-width: $breakpoint-md) {
+    padding: 0 $spacing-sm $spacing-xl;
+    padding-top: $spacing-md;
+  }
+}
+
+.footerLink {
+  font-size: $font-size-sm;
+  color: var(--text-color-secondary);
+  text-decoration: none;
+  transition: color 0.3s ease;
+
+  &:hover {
+    color: var(--primary-color);
+  }
+
+  & + & {
+    margin-left: $spacing-md;
+  }
+}

--- a/components/HighlightsForBooks/HighlightsLanding.tsx
+++ b/components/HighlightsForBooks/HighlightsLanding.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+import styles from "./HighlightsLanding.module.scss";
+
+const features = [
+  {
+    icon: "📚",
+    title: "Automatic Sync",
+    desc: "Reads directly from your Apple Books library. Your highlights appear instantly.",
+  },
+  {
+    icon: "🎨",
+    title: "Color-Coded Highlights",
+    desc: "See your highlights organized by color, just like in Apple Books.",
+  },
+  {
+    icon: "🔍",
+    title: "Powerful Search",
+    desc: "Find any highlight or note across your entire library in seconds.",
+  },
+  {
+    icon: "⭐",
+    title: "Favorites",
+    desc: "Star your most important highlights for quick access later.",
+  },
+  {
+    icon: "📖",
+    title: "Chapter Organization",
+    desc: "Browse highlights organized by chapter for context and flow.",
+  },
+  {
+    icon: "🔒",
+    title: "Privacy-First",
+    desc: "No network connections, no analytics, no tracking. Your data never leaves your Mac.",
+  },
+];
+
+const HighlightsLanding = () => {
+  return (
+    <div className={styles.page}>
+      {/* Hero */}
+      <section className={styles.hero}>
+        <h1 className={styles.appName}>Highlights for Books</h1>
+        <p className={styles.tagline}>
+          Your Apple Books highlights and notes in one beautiful, searchable
+          interface.
+        </p>
+        <div className={styles.platformBadge}>
+          <span>Available on the Mac App Store</span>
+        </div>
+        <div className={styles.ctaGroup}>
+          <a
+            href="#"
+            className={styles.ctaButton}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Download on the Mac App Store
+          </a>
+          <span className={styles.price}>$4.99 &middot; macOS 14.0+</span>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className={styles.features}>
+        <h2 className={styles.sectionTitle}>Features</h2>
+        <div className={styles.featureGrid}>
+          {features.map((f) => (
+            <div key={f.title} className={styles.featureCard}>
+              <span className={styles.featureIcon}>{f.icon}</span>
+              <h3 className={styles.featureTitle}>{f.title}</h3>
+              <p className={styles.featureDesc}>{f.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Requirements */}
+      <section className={styles.requirements}>
+        <h2 className={styles.sectionTitle}>System Requirements</h2>
+        <ul className={styles.requirementsList}>
+          <li className={styles.requirementItem}>
+            <strong>Platform:</strong> macOS
+          </li>
+          <li className={styles.requirementItem}>
+            <strong>Requires:</strong> macOS 14.0 (Sonoma) or later
+          </li>
+          <li className={styles.requirementItem}>
+            <strong>Price:</strong> $4.99 (one-time purchase)
+          </li>
+        </ul>
+      </section>
+
+      {/* Support */}
+      <section className={styles.support}>
+        <h2 className={styles.sectionTitle}>Support</h2>
+        <p className={styles.supportText}>
+          Have a question, found a bug, or need help getting started? Reach out
+          and I will get back to you as soon as possible.
+        </p>
+        <a
+          href="mailto:maalik@maalik.dev"
+          className={styles.supportEmail}
+        >
+          maalik@maalik.dev
+        </a>
+      </section>
+
+      {/* Footer Links */}
+      <div className={styles.footerLinks}>
+        <Link href="/highlights-for-books/privacy" className={styles.footerLink}>
+          Privacy Policy
+        </Link>
+        <Link href="/" className={styles.footerLink}>
+          maalikahmad.tech
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default HighlightsLanding;

--- a/components/HighlightsForBooks/HighlightsPrivacy.module.scss
+++ b/components/HighlightsForBooks/HighlightsPrivacy.module.scss
@@ -1,0 +1,121 @@
+@use "../../styles/variables" as *;
+
+.page {
+  min-height: 100vh;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.article {
+  max-width: 750px;
+  margin: 0 auto;
+  padding: 120px $spacing-md $spacing-2xl;
+
+  @media (max-width: $breakpoint-md) {
+    padding: 100px $spacing-sm $spacing-xl;
+  }
+}
+
+.backLink {
+  display: inline-block;
+  font-size: $font-size-sm;
+  font-weight: 500;
+  color: var(--text-color-secondary);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: $spacing-xl;
+  transition: color 0.3s ease;
+
+  &:hover {
+    color: var(--primary-color);
+  }
+}
+
+.header {
+  margin-bottom: $spacing-xl;
+}
+
+.title {
+  font-family: var(--font-primary);
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: var(--text-color);
+  line-height: 1.2;
+  margin: 0 0 $spacing-xs;
+
+  @media (max-width: $breakpoint-md) {
+    font-size: 2rem;
+  }
+
+  @media (max-width: $breakpoint-sm) {
+    font-size: 1.75rem;
+  }
+}
+
+.effectiveDate {
+  font-size: $font-size-sm;
+  color: var(--text-color-secondary);
+  margin: 0;
+}
+
+.content {
+  font-size: 1.0625rem;
+  line-height: 1.8;
+  color: var(--text-color);
+
+  h2 {
+    font-size: 1.375rem;
+    font-weight: 600;
+    margin: 2.5rem 0 0.75rem;
+    color: var(--text-color);
+  }
+
+  p {
+    margin: 0 0 1.25rem;
+  }
+
+  ul {
+    margin: 0 0 1.25rem;
+    padding-left: 1.5rem;
+    list-style-type: disc;
+
+    li {
+      margin-bottom: 0.4rem;
+    }
+  }
+
+  a {
+    color: var(--primary-color);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.3s ease;
+
+    &:hover {
+      border-bottom-color: var(--primary-color);
+    }
+  }
+
+  strong {
+    font-weight: 600;
+  }
+}
+
+.contactSection {
+  margin-top: $spacing-xl;
+  padding-top: $spacing-lg;
+  border-top: 1px solid var(--card-border);
+}
+
+.contactEmail {
+  display: inline-block;
+  font-weight: 600;
+  color: var(--primary-color);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.3s ease;
+
+  &:hover {
+    border-bottom-color: var(--primary-color);
+  }
+}

--- a/components/HighlightsForBooks/HighlightsPrivacy.tsx
+++ b/components/HighlightsForBooks/HighlightsPrivacy.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link";
+import styles from "./HighlightsPrivacy.module.scss";
+
+const HighlightsPrivacy = () => {
+  return (
+    <div className={styles.page}>
+      <article className={styles.article}>
+        <Link href="/highlights-for-books" className={styles.backLink}>
+          &larr; Back to Highlights for Books
+        </Link>
+
+        <header className={styles.header}>
+          <h1 className={styles.title}>Privacy Policy</h1>
+          <p className={styles.effectiveDate}>
+            Effective date: March 31, 2026
+          </p>
+        </header>
+
+        <div className={styles.content}>
+          <p>
+            Highlights for Books (&ldquo;the App&rdquo;) is a macOS application
+            developed by Maalik Ahmad. This privacy policy explains how the App
+            handles your data.
+          </p>
+
+          <h2>No Data Collection</h2>
+          <p>
+            <strong>
+              Highlights for Books does not collect, store, or transmit any
+              personal data.
+            </strong>{" "}
+            The App has no user accounts, no registration, and no cloud
+            services. Your information stays entirely on your Mac.
+          </p>
+
+          <h2>No Network Connections</h2>
+          <p>
+            The App makes <strong>zero network connections</strong>. It does not
+            connect to the internet for any reason. There is no analytics, no
+            telemetry, no crash reporting, and no tracking of any kind.
+          </p>
+
+          <h2>Local Data Access</h2>
+          <p>
+            Highlights for Books reads data from the local Apple Books SQLite
+            databases on your Mac, specifically:
+          </p>
+          <ul>
+            <li>
+              <strong>BKLibrary</strong> &mdash; your Apple Books library
+              metadata
+            </li>
+            <li>
+              <strong>AEAnnotation</strong> &mdash; your highlights, notes, and
+              annotations
+            </li>
+          </ul>
+          <p>
+            This data is read locally and is never copied, uploaded, or shared
+            with anyone. All processing happens entirely on your device.
+          </p>
+
+          <h2>File Access Permissions</h2>
+          <p>
+            The App uses macOS <strong>security-scoped bookmarks</strong> to
+            request and remember your permission to access the Apple Books
+            database files. This is the standard macOS mechanism for sandboxed
+            apps to access files outside their container. You grant permission
+            once, and the App remembers it for future sessions.
+          </p>
+
+          <h2>Third-Party Services</h2>
+          <p>
+            Highlights for Books uses <strong>no third-party services</strong>,
+            SDKs, frameworks, or libraries that collect data. The App is
+            entirely self-contained.
+          </p>
+
+          <h2>Children&rsquo;s Privacy</h2>
+          <p>
+            Since the App collects no data whatsoever, there are no special
+            considerations regarding children&rsquo;s privacy. The App is safe
+            for users of all ages.
+          </p>
+
+          <h2>Changes to This Policy</h2>
+          <p>
+            If this privacy policy is ever updated, the changes will be posted
+            on this page with a revised effective date. Given the App&rsquo;s
+            zero-data-collection design, material changes are unlikely.
+          </p>
+
+          <div className={styles.contactSection}>
+            <h2>Contact</h2>
+            <p>
+              If you have any questions about this privacy policy, please
+              contact:
+            </p>
+            <p>
+              <a
+                href="mailto:maalik@maalik.dev"
+                className={styles.contactEmail}
+              >
+                maalik@maalik.dev
+              </a>
+            </p>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+};
+
+export default HighlightsPrivacy;

--- a/pages/highlights-for-books/index.tsx
+++ b/pages/highlights-for-books/index.tsx
@@ -1,0 +1,91 @@
+import Head from "next/head";
+import Navbar from "@/components/NavBar/Navbar";
+import HighlightsLanding from "@/components/HighlightsForBooks/HighlightsLanding";
+
+const HighlightsForBooksPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Highlights for Books | Maalik Ahmad</title>
+        <meta
+          name="description"
+          content="Highlights for Books reads your Apple Books highlights and notes into one beautiful, searchable interface. Available on the Mac App Store for $4.99."
+        />
+        <link
+          rel="canonical"
+          href="https://www.maalikahmad.tech/highlights-for-books"
+        />
+
+        {/* Open Graph */}
+        <meta
+          property="og:title"
+          content="Highlights for Books | Maalik Ahmad"
+        />
+        <meta
+          property="og:description"
+          content="Your Apple Books highlights and notes in one beautiful, searchable interface. Privacy-first macOS app — no tracking, no network connections."
+        />
+        <meta
+          property="og:url"
+          content="https://www.maalikahmad.tech/highlights-for-books"
+        />
+        <meta property="og:type" content="website" />
+        <meta
+          property="og:image"
+          content="https://www.maalikahmad.tech/homescreen.png"
+        />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:site_name" content="Maalik Ahmad Tech" />
+
+        {/* Twitter */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content="Highlights for Books | Maalik Ahmad"
+        />
+        <meta
+          name="twitter:description"
+          content="Your Apple Books highlights and notes in one beautiful, searchable interface. Privacy-first macOS app."
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.maalikahmad.tech/homescreen.png"
+        />
+
+        {/* Structured Data - SoftwareApplication */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "SoftwareApplication",
+              name: "Highlights for Books",
+              operatingSystem: "macOS 14.0+",
+              applicationCategory: "UtilitiesApplication",
+              offers: {
+                "@type": "Offer",
+                price: "4.99",
+                priceCurrency: "USD",
+                availability: "https://schema.org/InStock",
+              },
+              description:
+                "Reads your Apple Books highlights and notes into one beautiful, searchable interface.",
+              author: {
+                "@type": "Person",
+                name: "Maalik Ahmad",
+                url: "https://www.maalikahmad.tech",
+              },
+            }),
+          }}
+        />
+      </Head>
+      <Navbar />
+      <main>
+        <HighlightsLanding />
+      </main>
+    </>
+  );
+};
+
+export default HighlightsForBooksPage;

--- a/pages/highlights-for-books/privacy.tsx
+++ b/pages/highlights-for-books/privacy.tsx
@@ -1,0 +1,42 @@
+import Head from "next/head";
+import Navbar from "@/components/NavBar/Navbar";
+import HighlightsPrivacy from "@/components/HighlightsForBooks/HighlightsPrivacy";
+
+const HighlightsPrivacyPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Privacy Policy — Highlights for Books | Maalik Ahmad</title>
+        <meta
+          name="description"
+          content="Privacy policy for Highlights for Books. The app collects no data, makes no network connections, and your highlights never leave your Mac."
+        />
+        <link
+          rel="canonical"
+          href="https://www.maalikahmad.tech/highlights-for-books/privacy"
+        />
+
+        {/* Open Graph */}
+        <meta
+          property="og:title"
+          content="Privacy Policy — Highlights for Books"
+        />
+        <meta
+          property="og:description"
+          content="Highlights for Books collects no data and makes no network connections. Your highlights never leave your Mac."
+        />
+        <meta
+          property="og:url"
+          content="https://www.maalikahmad.tech/highlights-for-books/privacy"
+        />
+        <meta property="og:type" content="website" />
+      </Head>
+      <Navbar />
+      <main>
+        <HighlightsPrivacy />
+      </main>
+    </>
+  );
+};
+
+export default HighlightsPrivacyPage;


### PR DESCRIPTION
## Summary
- Adds landing/support page at `/highlights-for-books` with app features, pricing ($4.99), and Mac App Store link
- Adds privacy policy page at `/highlights-for-books/privacy` documenting zero-data-collection approach
- Required for App Store Connect submission (support URL + privacy policy URL)

## Test plan
- [ ] Verify `/highlights-for-books` renders correctly with app description and features
- [ ] Verify `/highlights-for-books/privacy` renders the privacy policy
- [ ] Check responsive layout on mobile/tablet sizes
- [ ] Confirm Vercel preview deployment looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)